### PR TITLE
Add an Effect on Active to kit-button-alt

### DIFF
--- a/d/kitstrap.css
+++ b/d/kitstrap.css
@@ -337,6 +337,11 @@ kit-button-alt:hover,
     color: white;
 }
 
+kit-button-alt:active,
+.kit-button-alt:active {
+    box-shadow: 0 0 0 3px rgba(180, 200, 255, .8);
+}
+
 .kit-button.small,
 kit-button.small,
 .kit-button-alt.small,


### PR DESCRIPTION
## Outline

- Add `:active` Effect to `kit-button-alt`

close #36 