### PR TITLE
#85 Add classes for position props

### DIFF
--- a/d/kitstrap.css
+++ b/d/kitstrap.css
@@ -1453,6 +1453,15 @@ kit-pane.dark.hover:hover,
     background-color: #ffffff;
 }
 
+.kit-bgclr {
+    background: -moz-linear-gradient(45deg, rgba(204, 255, 216, 1) 0%, rgba(212, 246, 255, 1) 38%, rgba(255, 219, 238, 1) 100%);
+    background: -webkit-gradient(left bottom, right top, color-stop(0%, rgba(204, 255, 216, 1)), color-stop(38%, rgba(212, 246, 255, 1)), color-stop(100%, rgba(255, 219, 238, 1)));
+    background: -webkit-linear-gradient(45deg, rgba(204, 255, 216, 1) 0%, rgba(212, 246, 255, 1) 38%, rgba(255, 219, 238, 1) 100%);
+    background: -o-linear-gradient(45deg, rgba(204, 255, 216, 1) 0%, rgba(212, 246, 255, 1) 38%, rgba(255, 219, 238, 1) 100%);
+    background: -ms-linear-gradient(45deg, rgba(204, 255, 216, 1) 0%, rgba(212, 246, 255, 1) 38%, rgba(255, 219, 238, 1) 100%);
+    background: linear-gradient(45deg, rgba(204, 255, 216, 1) 0% rgba(212, 246, 255, 1) 38%, rgba(255, 219, 238, 1) 100%);
+}
+
 /* legacy color classes */
 
 .orange,
@@ -1678,6 +1687,29 @@ kit-button-alt.black:hover {
 
 .kit-flex-order-1 {
     order: -1;
+}
+
+/* position */
+
+.kit-static {
+    position: static;
+}
+
+.kit-relative {
+    position: relative;
+}
+
+.kit-absolute {
+    position: absolute;
+}
+
+.kit-fixed {
+    position: fixed;
+}
+
+.kit-sticky {
+    position: sticky;
+    top: 0;
 }
 
 /* other function */

--- a/docs/layouts.html
+++ b/docs/layouts.html
@@ -144,6 +144,32 @@ margin
 
         <h2>
             <kit-badge class="orange">class</kit-badge>
+            position
+        </h2>
+        <p class="m-l">
+            kitstrapには、要素の<code>position</code>プロパティを変更するためのクラスが用意されています。
+        </p>
+        <h4>position関連クラス</h4>
+        <ul>
+            <li>
+                <code>.kit-static</code>は、要素のpositionを<code>static</code>にします。
+            </li>
+            <li>
+                <code>.kit-relative</code>は、要素のpositionを<code>relative</code>にします。
+            </li>
+            <li>
+                <code>.kit-absolute</code>は、要素のpositionを<code>absolute</code>にします。
+            </li>
+            <li>
+                <code>.kit-fixed</code>は、要素のpositionを<code>fixed</code>にします。
+            </li>
+            <li>
+                <code>.kit-sticky</code>は、要素のpositionを<code>stciky</code>にします。
+            </li>
+        </ul>
+
+        <h2>
+            <kit-badge class="orange">class</kit-badge>
             flexシステム
         </h2>
         <p class="m-l">


### PR DESCRIPTION
## Outline

- Add classes for CSS position properties `.kit-static`, `.kit-relative`, `.kit-absolute`, `.kit-sticky` and `.kit-fixed`

close #85 