### PR TITLE
#99 Add xxlarge and xsmall child class to kit-button

### DIFF
--- a/d/kitstrap.css
+++ b/d/kitstrap.css
@@ -617,6 +617,14 @@ kit-button-alt.-black:hover {
     background: #353535;
 }
 
+.kit-button.-xsmall,
+kit-button.-xsmall,
+.kit-button-alt.-xsmall,
+kit-button-alt.-xsmall {
+    font-size: 10px;
+    padding: 0px 3px;
+}
+
 .kit-button.small,
 kit-button.small,
 .kit-button-alt.small,
@@ -679,6 +687,14 @@ kit-button.-xlarge,
 kit-button-alt.-xlarge {
     font-size: 27px;
     padding: 5px 20px;
+}
+
+.kit-button.-xxlarge,
+kit-button.-xxlarge,
+.kit-button-alt.-xxlarge,
+kit-button-alt.-xxlarge {
+    font-size: 34px;
+    padding: 12px 34px;
 }
 
 .kit-button.-disabled,

--- a/docs/elements.html
+++ b/docs/elements.html
@@ -51,10 +51,11 @@
             </kit-box>
         </kit-container>
         <blockquote class="m-l">デフォルトのカラーはdodgerblueです</blockquote>
-        <p class="m-l">　kit-buttonの子クラス<code>.-xlarge</code>、<code>.-large</code>、<code>.-medium</code>と<code>.-small</code>でボタンのサイズを変更することもできます。</p>
+        <p class="m-l">　kit-buttonの子クラス<code>.-xxlarge</code>、<code>.-xlarge</code>、<code>.-large</code>、<code>.-medium</code>、<code>.-small</code>と<code>.-xsmall</code>でボタンのサイズを変更することもできます。</p>
         <kit-container class="m-l">
             <kit-box>
                 <h5>プレビュー</h5>
+                <kit-button class="-xsmall">-xsmall</kit-button>
                 <kit-button class="-small">-small</kit-button>
                 <kit-button class="-medium">-medium</kit-button>
                 <kit-button class="-large">-large</kit-button>
@@ -62,6 +63,7 @@
             </kit-box>
             <kit-box>
                 <h5>プレビュー(kit-button-alt)</h5>
+                <kit-button-alt class="-xsmall">-xsmall</kit-button-alt>
                 <kit-button-alt class="-small">-small</kit-button-alt>
                 <kit-button-alt class="-medium">-medium</kit-button-alt>
                 <kit-button-alt class="-large">-large</kit-button-alt>

--- a/docs/index.html
+++ b/docs/index.html
@@ -21,6 +21,12 @@
     <main class="p-l">
         <img src="./banner.png" style="max-width: calc(100% - 40px)" class="m-l">
         <p class="m-l">　kitstrapドキュメントのサンプルへようこそ！ここではkitstrapの導入方法から設置できる部品、kitstrapレイアウトまでご紹介しています。<br>　このWebページもkitstrapで作られています。このページのソースコードを読んでみることはkitstrapを理解する手助けになるかもしれません。<br>　より詳しい情報は<a href="https://github.com/mtsgi/kitstrap/wiki" class="kit-hyperlink">kitstrapのWiki</a>からも確認することができます。</p>
+        <p class="kit-text-c m">
+            <span class="kit-tipped">
+                <a href="./installation.html" class="kit-button-alt -limegreen -xxlarge">使いはじめる</a>
+                <kit-tip class="-bottom">.kit-button-alt .-limegreen .-xxlarge</kit-tip>
+            </span>
+        </p>
         <kit-container class="m-l">
             <a href="./installation.html" class="kit-box kit-hl-alt">
                 <div class="kit-title">導入方法</div>


### PR DESCRIPTION
## Outline

- Add `.-xsmall` child class to `kit-button` in order to set the button smaller.
- Add `.-xxlarge` child class to `kit-button` in order to set the button larger.

close #99 