### PR TITLE
#105 Fix border style of kit-button-alt submit buttons

### DIFF
--- a/d/kitstrap.css
+++ b/d/kitstrap.css
@@ -523,7 +523,6 @@ input[type="button"].kit-button-alt {
     -webkit-box-sizing: content-box;
     -webkit-appearance: button;
     appearance: button;
-    border: none;
     box-sizing: border-box;
     cursor: pointer;
 }


### PR DESCRIPTION
## Outline

- Fix border style of kit-button-alt when set a color class
- Ex: `<input type="submit" class="kit-button-alt -deeppink" />`

close #105 